### PR TITLE
testing feedback

### DIFF
--- a/client/react/package.json
+++ b/client/react/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dist; mkdir -p ./dist",
     "prod": "cp -r ./dist/ ../../server/dist/; cd ../../server; npm run prod",
     "server": "cd ../../server && npm run dev",
-    "watch": "concurrently --kill-others 'npm run server' 'npm run check-types -- --watch' 'sleep 3; npm run dev'"
+    "watch": "concurrently --kill-others 'npm run server' 'npm run check-types -- --watch --preserveWatchOutput' 'sleep 3; npm run dev'"
   },
   "dependencies": {
     "classnames": "^2.3.1",

--- a/client/react/vite.config.ts
+++ b/client/react/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://127.0.0.1:8080',
       },
     },
   },

--- a/client/ts-web-component/package.json
+++ b/client/ts-web-component/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./dist; mkdir -p ./dist",
     "prod": "cp -r ./dist/ ../../server/dist/; cd ../../server; npm run prod",
     "server": "cd ../../server && npm run dev",
-    "watch": "concurrently --kill-others 'npm run server' 'npm run check-types -- --watch' 'sleep 3; npm run dev'"
+    "watch": "concurrently --kill-others 'npm run server' 'npm run check-types -- --watch --preserveWatchOutput' 'sleep 3; npm run dev'"
   },
   "dependencies": {
     "nanoid": "^4.0.0",

--- a/client/ts-web-component/vite.config.ts
+++ b/client/ts-web-component/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://127.0.0.1:8080',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-replicache-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "devDependencies": {
     "@rocicorp/eslint-config": "^0.1.2",
     "@rocicorp/prettier-config": "^0.1.1",


### PR DESCRIPTION
- On MacOS, localhost tries to access an IPV6 localhost, which Express server isn't listening on.
- Added a flag to not clear watch output (so that we can see the port to go to for vite)